### PR TITLE
Feat: bump Horizon chart version to v2.0.2

### DIFF
--- a/charts/horizon/Chart.yaml
+++ b/charts/horizon/Chart.yaml
@@ -4,7 +4,7 @@ description: A CICD DevOps Platform
 
 type: application
 
-version: 2.0.1
+version: 2.0.2
 appVersion: v2.0.1
 
 dependencies:

--- a/charts/horizon/templates/core/core-dpl.yaml
+++ b/charts/horizon/templates/core/core-dpl.yaml
@@ -20,6 +20,9 @@ spec:
       labels:
 {{ include "horizon.matchLabels" . | indent 8 }}
         component: core
+{{- if .Values.core.additionalLabels }}
+{{ toYaml .Values.core.additionalLabels | indent 8 }}
+{{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config-cm.yaml") . | sha256sum }}
         {{- if .Values.core.podAnnotations }}

--- a/charts/horizon/templates/job/job-dpl.yaml
+++ b/charts/horizon/templates/job/job-dpl.yaml
@@ -18,6 +18,9 @@ spec:
       labels:
 {{ include "horizon.matchLabels" . | indent 8 }}
         component: job
+{{- if .Values.job.additionalLabels }}
+{{ toYaml .Values.job.additionalLabels | indent 8 }}
+{{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config-cm.yaml") . | sha256sum }}
     spec:

--- a/charts/horizon/values.yaml
+++ b/charts/horizon/values.yaml
@@ -45,7 +45,7 @@ config:
       kubeconfig: ""
       s3:
         accessKey: admin
-        secretKey: admin
+        secretKey: qOIh3Xt5jg
         region: china
         endpoint: "{{ .Release.Name }}-minio:9000"
         bucket: horizon
@@ -94,12 +94,13 @@ ingress:
 
 core:
   replicas: 1
+  additionalLabels: {}
   image:
     repository: horizoncd/horizon-core
     tag: v2.0.1
   args:
     loglevel:
-    gitOpsRepoDefaultBranch: main
+    gitOpsRepoDefaultBranch: master
   securityContext:
     runAsUser: 10001
     fsGroup: 10001
@@ -2058,12 +2059,13 @@ core:
 
 
 job:
+  additionalLabels: {}
   image:
     repository: horizoncd/horizon-job
     tag: v2.0.1
   args:
     loglevel:
-    gitOpsRepoDefaultBranch: main
+    gitOpsRepoDefaultBranch: master
   securityContext:
     runAsUser: 10001
     fsGroup: 10001
@@ -3090,7 +3092,7 @@ mysql:
 gitlab:
   enabled: true
   image: gitlab/gitlab-ce
-  imageTag: "15.5.1-ce.0"
+  imageTag: "13.11.7-ce.0"
   ingress:
     enabled: true
     hosts:

--- a/charts/tektoncd/Chart.yaml
+++ b/charts/tektoncd/Chart.yaml
@@ -7,4 +7,4 @@ version: 2.0.1
 
 appVersion: 0.18.1
 
-description: Helm chart for Tekton pipelines， Tekton triggers and Tekton dashboard.
+description: Helm chart for Tekton pipelines，Tekton triggers and Tekton dashboard.


### PR DESCRIPTION
- set gitlab image version to `13.11.7-ce.0` 
- support setting `additionalLabels` for core & web module 
- set `gitOpsRepoDefaultBranch` to master