### PR TITLE
fix: format

### DIFF
--- a/charts/horizon/charts/tektonci-resources/values.yaml
+++ b/charts/horizon/charts/tektonci-resources/values.yaml
@@ -323,7 +323,7 @@ horizon:
       }
       deploy
 auth:
-  dockerConfigJson: "{}"
+  dockerConfigJson: {}
 podmanConfig: |
   [registries.search]
   unqualified-search-registries = ['docker.io']


### PR DESCRIPTION
warning log: dockerConfigJson is a table. Ignoring non-table value ({})