### PR TITLE
fix: replace deprecated field template.name with template.ref

### DIFF
--- a/charts/horizon/Chart.yaml
+++ b/charts/horizon/Chart.yaml
@@ -4,7 +4,7 @@ description: A CICD DevOps Platform
 
 type: application
 
-version: 2.2.4
+version: 2.2.5
 appVersion: v2.4.1
 dependencies:
   - name: common

--- a/charts/horizon/charts/tektonci-resources/templates/horizon/trigger-el.yaml
+++ b/charts/horizon/charts/tektonci-resources/templates/horizon/trigger-el.yaml
@@ -23,7 +23,7 @@ spec:
     - bindings:
       - ref: horizon-taskbinding
       template:
-        name: horizon-triggertemplate
+        ref: horizon-triggertemplate
       interceptors:
         - cel:
             overlays:


### PR DESCRIPTION
Deprecated field `template.Name` in eventlistener is removed in tekton trigger v0.12.0 in favour of `template.Ref`. 

link: https://github.com/tektoncd/triggers/pull/919